### PR TITLE
CapFrameX.Data: ignore Viber

### DIFF
--- a/source/CapFrameX.Data/ProcessList/Processes.json
+++ b/source/CapFrameX.Data/ProcessList/Processes.json
@@ -1830,6 +1830,11 @@
     "IsBlacklisted": false
   },
   {
+    "Name": "Viber",
+    "DisplayName": null,
+    "IsBlacklisted": true
+  },
+  {
     "Name": "Video.UI",
     "DisplayName": null,
     "IsBlacklisted": true


### PR DESCRIPTION
There is no need to show FPS stats in instant messenger.