### PR TITLE
SystemInfo: fix ReBar usage detection via D3DKMT

### DIFF
--- a/source/CapFrameX.SystemInfo.NetStandard/CapFrameX.SystemInfo.NetStandard.csproj
+++ b/source/CapFrameX.SystemInfo.NetStandard/CapFrameX.SystemInfo.NetStandard.csproj
@@ -6,9 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="Mixaill.HwInfo.D3D" Version="0.4.0" />
-    <PackageReference Include="Mixaill.HwInfo.SetupApi" Version="0.4.0" />
-    <PackageReference Include="Mixaill.HwInfo.Vulkan" Version="0.4.0" />
+    <PackageReference Include="Mixaill.HwInfo.D3D" Version="0.4.2" />
+    <PackageReference Include="Mixaill.HwInfo.SetupApi" Version="0.4.2" />
+    <PackageReference Include="Mixaill.HwInfo.Vulkan" Version="0.4.2" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
* update Mixaill.HwInfo from v0.4.0 to v0.4.2
  * fixes ReBAR usage detection via D3DKMT for Intel ARC
  * fixes ReBAR usage detection via D3DKMT for entry level NVIDIA products like GT710