### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,18 +20,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 9.0.x
 
       - name: Setup NuGet
-        uses: nuget/setup-nuget@v2
+        uses: nuget/setup-nuget@v4
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         with:
           vs-version: '[18.0, 19.0)'
 
@@ -267,13 +267,13 @@ jobs:
             -Force
 
       - name: Upload installer artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: capframex-installer-${{ steps.vars.outputs.filename }}
           path: ${{ steps.vars.outputs.filename }}_installer.zip
 
       - name: Upload portable artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: capframex-portable-${{ steps.vars.outputs.filename }}
           path: ${{ steps.vars.outputs.filename }}_portable.zip
@@ -288,7 +288,7 @@ jobs:
 
     steps:
       - name: Download workflow artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: capframex-*
           merge-multiple: true


### PR DESCRIPTION
### ci: update GitHub Actions to silence Node.js runtime deprecation warnings

#### Summary
This PR updates the github-actions in `main.yml` to their latest supported versions.

The current workflow triggers runtime deprecation warnings on `windows-latest` runners:
> `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24...`

Upgrading these action versions eliminates these warnings and ensures long-term pipeline stability before GitHub completely drops Node 20 execution support on runners.

---

#### Changes
- Updated `actions/checkout`, `setup-dotnet`, `upload-artifact`, `download-artifact`, `setup-msbuild`, and `setup-nuget` to their latest releases.

Beyond updating the actions, this change addresses security vulnerabilities present in older versions. It also provides a minor performance boost for upload-artifact and download-artifact.

Of course, there's no need to rush this, as version bumps can sometimes introduce unexpected bugs. However, in this case, these newer versions have been tested and haven't shown any issues so far.

As a potential qof improvement down the road, it might also be worth enabling Dependabot on a monthly schedule, purely to keep us informed about available updates.

---

#### Verification
Tested on a fork build: binary builds, installers, and artifact uploads executed with 0 errors.
https://github.com/independent-arg/CapFrameX/actions/runs/32256357077