### PR TITLE
fix(IGCL): resolve compiler warnings in IGCLManager

### DIFF
--- a/source/CapFrameX.IGCL/IGCLManager.cpp
+++ b/source/CapFrameX.IGCL/IGCLManager.cpp
@@ -142,9 +142,10 @@ uint32_t GetBusWidth(const uint32_t index)
 
 					if (res == CTL_RESULT_SUCCESS)
 					{
-						if (memoryProperties.busWidth > busWidth)
+						if (memoryProperties.busWidth > 0 &&
+                            static_cast<uint32_t>(memoryProperties.busWidth) > busWidth)
 						{
-							busWidth = memoryProperties.busWidth;
+							busWidth = static_cast<uint32_t>(memoryProperties.busWidth);
 						}
 					}
 				}

--- a/source/CapFrameX.IGCL/IGCLManager.h
+++ b/source/CapFrameX.IGCL/IGCLManager.h
@@ -4,7 +4,7 @@
 
 #define CTL_MAX_DRIVER_VERSION_LEN  25
 
-typedef struct IgclTelemetryData
+struct IgclTelemetryData
 {
 	// GPU TDP
 	bool gpuEnergySupported = false;
@@ -67,7 +67,7 @@ typedef struct IgclTelemetryData
 	double fanSpeedValue;
 };
 
-typedef struct IgclDeviceInfo
+struct IgclDeviceInfo
 {
 	char DeviceName[CTL_MAX_DEVICE_NAME_LEN];
 	DWORD AdapterID;
@@ -78,7 +78,7 @@ typedef struct IgclDeviceInfo
 	uint32_t Adapter_Property_Flag;
 };
 
-#define IGCL_API __declspec(dllimport)
+#define IGCL_API __declspec(dllexport)
 
 extern "C" IGCL_API bool IntializeIgcl();
 
@@ -91,4 +91,3 @@ extern "C" IGCL_API uint32_t GetBusWidth(const uint32_t index);
 extern "C" IGCL_API bool GetDeviceInfo(const uint32_t index, IgclDeviceInfo *igclDeviceInfo);
 
 extern "C" IGCL_API bool GetIgclTelemetryData(const uint32_t index, IgclTelemetryData *igclTelemetryData);
-

--- a/source/CapFrameX.IGCL/IGCLManager.h
+++ b/source/CapFrameX.IGCL/IGCLManager.h
@@ -78,7 +78,11 @@ struct IgclDeviceInfo
 	uint32_t Adapter_Property_Flag;
 };
 
+#ifdef CAPFRAMEXIGCL_EXPORTS
 #define IGCL_API __declspec(dllexport)
+#else
+#define IGCL_API __declspec(dllimport)
+#endif
 
 extern "C" IGCL_API bool IntializeIgcl();
 


### PR DESCRIPTION
I noticed that in each GitHub Actions run, there are about 40 warnings (according to the last one). 
Yes, the vast majority are normal warnings and nothing to worry about, but I found some that are highly fixable, especially in `IGCLManager.h` and `IGCLManager.cpp`.

<img width="459" height="491" alt="warnings" src="https://github.com/user-attachments/assets/a2d8abcf-8de0-4074-ab9d-ea9a36bcf5b9" />


- Fix inconsistent DLL linkage: IGCLManager.h declared all exported
  functions as __declspec(dllimport), while IGCLManager.cpp defines
  them in this same project (CapFrameX.IGCL.dll). Changed to
  __declspec(dllexport) to match. Resolves 6x C4273 warnings
  (IntializeIgcl, CloseIgcl, GetAdpaterCount, GetBusWidth,
  GetDeviceInfo, GetIgclTelemetryData).

- Remove unnecessary `typedef` on IgclTelemetryData and
  IgclDeviceInfo. C++ struct declarations already name the type;
  no alias was ever used. Resolves 2x "typedef ignored" warnings.

- Fix signed/unsigned comparison in GetBusWidth: igcl_api.h defines
  ctl_mem_properties_t::busWidth as int32_t, where -1 means
  "unknown". Comparing it directly against the local uint32_t
  accumulator implicitly promoted -1 to UINT32_MAX, letting an
  "unknown" reading win the max-width comparison. Now guards
  against non-positive values before the unsigned comparison.

No behavioral change is expected from the linkage/typedef cleanup.
The busWidth fix corrects a latent edge case that only triggers
when a memory module reports an unknown bus width.

---

Verification: 
builds cleanly, and these 9/10 warnings no longer appear in the build output.
https://github.com/independent-arg/CapFrameX/actions/runs/32315430590

I also ran the app from that specific run and nothing seems to be broken, so I would like to get your thoughts on this. 
Thanks!