### PR TITLE
Fix SHA1Managed obsolete warning (SYSLIB0021) in StringExtensions

### DIFF
--- a/source/CapFrameX.Extensions/StringExtensions.cs
+++ b/source/CapFrameX.Extensions/StringExtensions.cs
@@ -76,13 +76,8 @@ namespace CapFrameX.Extensions
         public static string GetSha1(this string value)
         {
             var data = Encoding.ASCII.GetBytes(value);
-            var hashData = new SHA1Managed().ComputeHash(data);
-            var hash = string.Empty;
-            foreach (var b in hashData)
-            {
-                hash += b.ToString("X2");
-            }
-            return hash;
+            var hashData = SHA1.HashData(data);
+            return Convert.ToHexString(hashData);
         }
 
         public static bool IsAllNotNullOrWhiteSpace(params string[] strings)

--- a/source/CapFrameX.Test/Extensions/StringExtensionsTest.cs
+++ b/source/CapFrameX.Test/Extensions/StringExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿using CapFrameX.Extensions;
+using CapFrameX.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CapFrameX.Test
@@ -18,6 +18,14 @@ namespace CapFrameX.Test
             Assert.AreEqual("ACOdyssey", gameName);
             Assert.AreEqual("2018-11-16", creationDate);
             Assert.AreEqual("220300", recordTime);
+        }
+
+        [TestMethod]
+        public void GetSha1_MatchesKnownValue()
+        {
+            Assert.AreEqual(
+                "A9993E364706816ABA3E25717850C26C9CD0D89D",
+                "abc".GetSha1());
         }
     }
 }


### PR DESCRIPTION
`GetSha1` used `SHA1Managed`, which is obsolete since .NET 5 (SYSLIB0021). Replaced with `SHA1.HashData()`, the modern static helper, and simplified the hex-encoding loop to `Convert.ToHexString()`.

No behavioral change: output format and hashed bytes are identical to the previous implementation.

---

Verification:
https://github.com/independent-arg/CapFrameX/actions/runs/32357470966