### PR TITLE
fix(Hwinfo): use conditional export/import macro for HWINFO_API

### DIFF
--- a/source/CapFrameX.Hwinfo/TimeStampCounterFrequency.h
+++ b/source/CapFrameX.Hwinfo/TimeStampCounterFrequency.h
@@ -1,7 +1,11 @@
 #pragma once
 #include <cstdint>
 
+#ifdef CAPFRAMEXHWINFO_EXPORTS
+#define HWINFO_API __declspec(dllexport)
+#else
 #define HWINFO_API __declspec(dllimport)
+#endif
 
 extern "C" HWINFO_API uint64_t GetTimeStampCounterFrequency();
 


### PR DESCRIPTION
Same issue as the recent `CapFrameX.IGCL` fix (#412): `TimeStampCounterFrequency.h` declared `GetTimeStampCounterFrequency` as `__declspec(dllimport)`, but it's defined within this same project (`CapFrameX.Hwinfo.dll`), causing an "inconsistent dll linkage" warning.

<img width="380" height="92" alt="Captura de pantalla 2026-08-20 224848" src="https://github.com/user-attachments/assets/6e5f18d8-6df3-4622-add5-4720f1319f8e" />


Switched HWINFO_API to the same conditional export/import macro pattern already used by ADLX_API and (now) IGCL_API, keyed off `CAPFRAMEXHWINFO_EXPORTS`, which the project already defines in all four build configurations, so no .vcxproj changes were needed.

Verified: builds cleanly, warning no longer appears in the build output.
https://github.com/independent-arg/CapFrameX/actions/runs/32437049892