### PR TITLE
fix(docs): correct stale CapFrameX.FrameView reference in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 
-- `source/` holds the main C# and C++ projects; the WPF app lives in `source/CapFrameX` and native components live in folders like `source/CapFrameX.Hwinfo`, `source/CapFrameX.FrameView`, `source/CapFrameX.IGCL`, and `source/CapFrameX.ADLX`.
+- `source/` holds the main C# and C++ projects; the WPF app lives in `source/CapFrameX` and native components live in folders like `source/CapFrameX.Hwinfo`, `source/CapFrameX.RTSSInterface`, `source/CapFrameX.IGCL`, and `source/CapFrameX.ADLX`.
 - Tests are in `source/CapFrameX.Test` (MSTest), with fixture files under `source/CapFrameX.Test/TestRecordFiles`.
 - Assets and documentation resources live in `images/` and project docs like `PORTABLE_MODE.md` and `README.md` live at the repo root.
 - Build and version metadata are in `CapFrameX.sln`, `packages/`, and the files under `version/`.


### PR DESCRIPTION
single-line change:
```diff
-native components live in folders like `source/CapFrameX.Hwinfo`, `source/CapFrameX.FrameView`, `source/CapFrameX.IGCL`, and `source/CapFrameX.ADLX`.
+native components live in folders like `source/CapFrameX.Hwinfo`, `source/CapFrameX.RTSSInterface`, `source/CapFrameX.IGCL`, and `source/CapFrameX.ADLX`.
```

`source/CapFrameX.FrameView` confirmed absent (`ls source/ | grep -i frameview` returns nothing)

---
replaced FrameView with RTSSInterface instead of just removing it from the list, which I believe is the correct approach