### PR TITLE
Prism 9.0.537 upgrade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ persistence layer was dropped. netcoreapp3.1 is out of support; the packages war
 - OxyPlot is consumed through NuGet packages rather than a repository project
 
 ### Key Dependencies
-- Prism 7.x (MVVM framework)
+- Prism 9.x (MVVM framework)
 - DryIoc (IoC container)
 - MahApps.Metro + MaterialDesign (UI styling)
 - System.Reactive (Rx)

--- a/source/CapFrameX.ApiInterface/CapFrameX.Remote.csproj
+++ b/source/CapFrameX.ApiInterface/CapFrameX.Remote.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DryIoc.dll" Version="4.1.0" />
+    <PackageReference Include="DryIoc.dll" Version="5.4.3" />
     <PackageReference Include="EmbedIO" Version="3.4.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />

--- a/source/CapFrameX.Data/CapFrameX.Data.csproj
+++ b/source/CapFrameX.Data/CapFrameX.Data.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.1.0" />
-    <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Core" Version="9.0.537" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>
 

--- a/source/CapFrameX.Extensions/CapFrameX.Extensions.csproj
+++ b/source/CapFrameX.Extensions/CapFrameX.Extensions.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DryIoc.dll" Version="4.1.0" />
+    <PackageReference Include="DryIoc.dll" Version="5.4.3" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />

--- a/source/CapFrameX.Extensions/ContainerExtensions.cs
+++ b/source/CapFrameX.Extensions/ContainerExtensions.cs
@@ -15,7 +15,7 @@ namespace CapFrameX.Extensions
 		public static void ConfigureSerilogILogger(this IContainer container, Serilog.ILogger logger)
 		{
 			var loggerFactory = CreateLoggerFactory(logger);
-			container.UseInstance(loggerFactory);
+			container.RegisterInstance(loggerFactory);
 			var loggerFactoryMethod = typeof(LoggerFactoryExtensions).GetMethod("CreateLogger", new Type[] { typeof(ILoggerFactory) });
 			container.Register(typeof(ILogger<>), made: Made.Of(req => loggerFactoryMethod.MakeGenericMethod(req.Parent.ImplementationType)));
 		}

--- a/source/CapFrameX.MVVM/CapFrameX.MVVM.csproj
+++ b/source/CapFrameX.MVVM/CapFrameX.MVVM.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="MaterialDesignColors" Version="5.2.1" />
     <PackageReference Include="MaterialDesignThemes" Version="5.2.1" />
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />
     <PackageReference Include="MouseKeyHook" Version="5.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />

--- a/source/CapFrameX.Mcp/CapFrameX.Mcp.csproj
+++ b/source/CapFrameX.Mcp/CapFrameX.Mcp.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="EmbedIO" Version="3.4.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="DryIoc.dll" Version="4.1.0" />
+    <PackageReference Include="DryIoc.dll" Version="5.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/CapFrameX.Overlay/CapFrameX.Overlay.csproj
+++ b/source/CapFrameX.Overlay/CapFrameX.Overlay.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Core" Version="9.0.537" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>
 

--- a/source/CapFrameX.PMD/CapFrameX.PMD.csproj
+++ b/source/CapFrameX.PMD/CapFrameX.PMD.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="OxyPlot.Core" Version="2.1.0" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.1.0" />
     <PackageReference Include="OxyPlot.Wpf.Shared" Version="2.1.0" />
-    <PackageReference Include="Prism.Core" Version="7.0.0.396" />
+    <PackageReference Include="Prism.Core" Version="9.0.537" />
     <PackageReference Include="SerialPortStream" Version="2.4.0" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>

--- a/source/CapFrameX.PresentMonInterface/CapFrameX.PresentMonInterface.csproj
+++ b/source/CapFrameX.PresentMonInterface/CapFrameX.PresentMonInterface.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="ConsoleAppLauncher" Version="1.0.6354.408" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Core" Version="9.0.537" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>

--- a/source/CapFrameX.Sensor/CapFrameX.Sensor.csproj
+++ b/source/CapFrameX.Sensor/CapFrameX.Sensor.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Core" Version="9.0.537" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>

--- a/source/CapFrameX.Test/CapFrameX.Test.csproj
+++ b/source/CapFrameX.Test/CapFrameX.Test.csproj
@@ -19,10 +19,10 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="DryIoc.dll" Version="4.1.0" />
+    <PackageReference Include="DryIoc.dll" Version="5.4.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Core" Version="2.1.0" />
-    <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Core" Version="9.0.537" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>
 

--- a/source/CapFrameX.View/CapFrameX.View.csproj
+++ b/source/CapFrameX.View/CapFrameX.View.csproj
@@ -28,11 +28,11 @@
     <PackageReference Include="MaterialDesignThemes.MahApps" Version="5.2.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.1.0" />
-    <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
-    <PackageReference Include="Prism.Wpf" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Core" Version="9.0.537" />
+    <PackageReference Include="Prism.Wpf" Version="9.0.537" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>
 

--- a/source/CapFrameX.ViewModel/AggregationViewModel.cs
+++ b/source/CapFrameX.ViewModel/AggregationViewModel.cs
@@ -11,7 +11,7 @@ using GongSolutions.Wpf.DragDrop;
 using Prism.Commands;
 using Prism.Events;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/source/CapFrameX.ViewModel/CapFrameX.ViewModel.csproj
+++ b/source/CapFrameX.ViewModel/CapFrameX.ViewModel.csproj
@@ -30,12 +30,12 @@
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />
     <PackageReference Include="MouseKeyHook" Version="5.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Core" Version="2.1.0" />
-    <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
-    <PackageReference Include="Prism.Wpf" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Core" Version="9.0.537" />
+    <PackageReference Include="Prism.Wpf" Version="9.0.537" />
     <PackageReference Include="Splat" Version="9.3.11" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
     <PackageReference Include="TaskScheduler" Version="2.9.1" />

--- a/source/CapFrameX.ViewModel/CaptureViewModel.cs
+++ b/source/CapFrameX.ViewModel/CaptureViewModel.cs
@@ -20,7 +20,7 @@ using OxyPlot.Legends;
 using Prism.Commands;
 using Prism.Events;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/source/CapFrameX.ViewModel/CloudViewModel.cs
+++ b/source/CapFrameX.ViewModel/CloudViewModel.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json.Linq;
 using Prism.Commands;
 using Prism.Events;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/source/CapFrameX.ViewModel/ColorbarViewModel.cs
+++ b/source/CapFrameX.ViewModel/ColorbarViewModel.cs
@@ -18,7 +18,7 @@ using Newtonsoft.Json;
 using Prism.Commands;
 using Prism.Events;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using System;
 using System.Collections.Generic;
 using System.Configuration;

--- a/source/CapFrameX.ViewModel/ComparisonDataViewModel.cs
+++ b/source/CapFrameX.ViewModel/ComparisonDataViewModel.cs
@@ -13,7 +13,7 @@ using OxyPlot.Axes;
 using Prism.Commands;
 using Prism.Events;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/source/CapFrameX.ViewModel/ComparisonViewModel.cs
+++ b/source/CapFrameX.ViewModel/ComparisonViewModel.cs
@@ -22,7 +22,7 @@ using OxyPlot.Legends;
 using Prism.Commands;
 using Prism.Events;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/source/CapFrameX.ViewModel/DataViewModel.cs
+++ b/source/CapFrameX.ViewModel/DataViewModel.cs
@@ -18,7 +18,7 @@ using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Events;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/source/CapFrameX.ViewModel/InfoViewModel.cs
+++ b/source/CapFrameX.ViewModel/InfoViewModel.cs
@@ -7,7 +7,7 @@ using CapFrameX.ViewModel.SubModels;
 using Microsoft.Extensions.Logging;
 using Prism.Events;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/source/CapFrameX.ViewModel/OverlayViewModel.cs
+++ b/source/CapFrameX.ViewModel/OverlayViewModel.cs
@@ -14,7 +14,7 @@ using CapFrameX.ViewModel.SubModels;
 using GongSolutions.Wpf.DragDrop;
 using Prism.Commands;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/source/CapFrameX.ViewModel/PmdViewModel.cs
+++ b/source/CapFrameX.ViewModel/PmdViewModel.cs
@@ -14,7 +14,7 @@ using OxyPlot;
 using Prism.Commands;
 using Prism.Events;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using System;
 using System.Globalization;
 using System.Linq;

--- a/source/CapFrameX.ViewModel/ReportViewModel.cs
+++ b/source/CapFrameX.ViewModel/ReportViewModel.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Events;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/source/CapFrameX.ViewModel/SensorViewModel.cs
+++ b/source/CapFrameX.ViewModel/SensorViewModel.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Events;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/source/CapFrameX.ViewModel/SynchronizationViewModel.cs
+++ b/source/CapFrameX.ViewModel/SynchronizationViewModel.cs
@@ -10,7 +10,7 @@ using OxyPlot.Axes;
 using Prism.Commands;
 using Prism.Events;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/source/CapFrameX/Bootstrapper.cs
+++ b/source/CapFrameX/Bootstrapper.cs
@@ -30,12 +30,13 @@ using CapFrameX.Updater;
 using CapFrameX.ViewModel;
 using DryIoc;
 using Microsoft.Extensions.Logging;
+using Prism.Container.DryIoc;
 using Prism.DryIoc;
 using Prism.Events;
 using Prism.Ioc;
 using Prism.Modularity;
 using Prism.Mvvm;
-using Prism.Regions;
+using Prism.Navigation.Regions;
 using Serilog;
 using System;
 using System.Configuration;
@@ -62,19 +63,7 @@ namespace CapFrameX
 
         // The existing composition root uses DryIoc-specific registration APIs. PrismApplication
         // exposes the container through Prism's abstraction, so unwrap it in one place.
-        private new IContainer Container => base.Container.GetContainer();
-
-        // Prism 7.2.0.1422 was compiled against DryIoc 4.0.7. DryIoc 4.1 changed the binary
-        // signature of Made.Of(), so PrismApplication's implementation throws a
-        // MissingMethodException before the container can be created. Recompile the equivalent
-        // rule set here against the DryIoc version referenced by this application.
-        protected override Rules CreateContainerRules()
-        {
-            return Rules.Default
-                .WithAutoConcreteTypeResolution()
-                .With(Made.Of(FactoryMethod.ConstructorWithResolvableArguments))
-                .WithDefaultIfAlreadyRegistered(IfAlreadyRegistered.Replace);
-        }
+        private new IContainer Container => ((DryIocContainerExtension)base.Container).Instance;
 
         /// <summary>
         /// While the splash screen is up, the shell stays minimized after its warm-up
@@ -91,7 +80,7 @@ namespace CapFrameX
             using (StartupPerformanceLogger.Measure("Shell resolution and construction"))
             {
                 var shell = Container.Resolve<Shell>();
-                Container.UseInstance<IShell>(shell);
+                Container.RegisterInstance<IShell>(shell);
                 return shell;
             }
         }

--- a/source/CapFrameX/CapFrameX.csproj
+++ b/source/CapFrameX/CapFrameX.csproj
@@ -73,7 +73,7 @@
   <Import Project="benchlab-service.items" Condition="Exists('benchlab-service.items')" />
 
   <ItemGroup>
-    <PackageReference Include="DryIoc.dll" Version="4.1.0" />
+    <PackageReference Include="DryIoc.dll" Version="5.4.3" />
     <PackageReference Include="EmbedIO" Version="3.4.3" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
     <PackageReference Include="Jot" Version="2.1.17" />
@@ -82,8 +82,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
-    <PackageReference Include="Prism.DryIoc" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Core" Version="9.0.537" />
+    <PackageReference Include="Prism.DryIoc" Version="9.0.537" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />

--- a/source/CapFrameX/RegionManagerWrapper.cs
+++ b/source/CapFrameX/RegionManagerWrapper.cs
@@ -1,4 +1,4 @@
-﻿using Prism.Regions;
+﻿using Prism.Navigation.Regions;
 using System;
 using System.Windows;
 
@@ -12,7 +12,7 @@ namespace CapFrameX
 
         public RegionManagerWrapper()
         {
-            RegionManager = Prism.Regions.RegionManager.GetRegionManager(Application.Current.MainWindow);
+            RegionManager = Prism.Navigation.Regions.RegionManager.GetRegionManager(Application.Current.MainWindow);
         }
 
         public static void ActivateView(string region, string view)

--- a/source/CapFrameX/Shell.xaml
+++ b/source/CapFrameX/Shell.xaml
@@ -1,6 +1,6 @@
 ﻿<Window x:Class="CapFrameX.Shell"
         x:Name="ShellWindow"
-        xmlns:prism="http://www.codeplex.com/prism"
+        xmlns:prism="http://prismlibrary.com/"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"


### PR DESCRIPTION
### Summary

**1. Versions Update (9 .csproj files)**
* Updated `Prism.Core`, `Prism.Wpf`, and `Prism.DryIoc` to version `9.0.537` across all projects.
* This includes `CapFrameX.PMD`, which was successfully upgraded from `7.0.0.396` to match the rest of the solution.

**2. DryIoc Dependency Bump (5 .csproj files)**
* Upgraded `DryIoc.dll` from `4.1.0` to `5.4.3` in the following projects: `CapFrameX.Extensions`, `CapFrameX.Test`, `CapFrameX.Remote`, `CapFrameX`, and `CapFrameX.Mcp`.
* This satisfies the minimum requirement for `Prism.Container.DryIoc` (`>= 9.0.106`) and removes the version mismatch between what this app referenced and what `Prism.DryIoc` was compiled against.

**3. Namespace Refactoring**
* Migrated `Prism.Regions` to `Prism.Navigation.Regions` across 14 files (13 ViewModels + `Bootstrapper.cs`), plus the fully-qualified reference in `RegionManagerWrapper.cs`.

**4. Bootstrapper.cs**
* `IContainerProvider.GetContainer()` no longer exists in Prism 9 - replaced with a direct cast to `DryIocContainerExtension` and its `.Instance` property (`Prism.Container.DryIoc` namespace), which is what that extension method did internally.
* Removed the custom `CreateContainerRules()` override. It existed to work around a historical binary mismatch between Prism 7.2.0.1422 (compiled against DryIoc 4.0.7) and this app's DryIoc.dll pin (4.1.0). With DryIoc.dll now aligned to 5.4.3, that mismatch no longer exists, and Prism 9's own internal default rules are more complete.

**5. Xaml Behaviors Alignment (3 .csproj files)**
* `Prism.Wpf` `9.0.537` requires `Microsoft.Xaml.Behaviors.Wpf >= 1.1.122`. The repo had it pinned to `1.1.39` in `CapFrameX.View`, `CapFrameX.ViewModel`, and `CapFrameX.MVVM`. All three have been updated to `1.1.122`.

**6. UseInstance Removal**
* `IContainer.UseInstance()` no longer exists in DryIoc 5.x (it was split into `RegisterInstance`/`Use` a while back, and the old alias was finally dropped). Replaced both call sites - the `ILoggerFactory` registration in `CapFrameX.Extensions/ContainerExtensions.cs` and the `IShell` registration in `Bootstrapper.cs`- with `RegisterInstance`, matching the pattern already used everywhere else in this codebase.

**7. XML Namespace Migration in Shell.xaml**
* `Shell.xaml` was still using the legacy XML namespace identifier (`http://www.codeplex.com/prism`, from the Prism 4/5 era) instead of the one every other view in the solution uses (`http://prismlibrary.com/`). Prism 9 dropped backward-compatibility mapping for the legacy URI during its Regions cleanup. Migrated it to match the rest of the codebase.

---

**Potential improvements from this upgrade:**
- Removes historical workarounds required to bridge Prism 7 with newer DryIoc versions.
- DryIoc 5.x brings performance and allocation improvements over the 4.x line this app was previously locked to (not independently benchmarked in this PR).
- Keeps XAML/WPF dependencies on actively maintained versions.

---

**I recommend not merging this PR just yet.** I am still performing QA testing on this major change. So far, it doesn't seem to have broken anything "at the moment," but I am still testing it thoroughly.

**Manual QA checklist (in progress):**
- [x] Region navigation across all tabs (Comparison, Cloud, Colorbar, PMD, Info, Data, Aggregation, Overlay, Sensor, Report, Capture)
- [x] Clean shutdown after a capture session — no lingering process/handles

Your verification, feedback, and potential improvements or anything I might have missed would be highly valuable @DevTechProfile

Feel free to test it out if you'd like: (verification)
https://github.com/independent-arg/CapFrameX/actions/runs/32796450443