### PR TITLE
Log missing first-run config files as Debug instead of Error

### DIFF
--- a/source/CapFrameX.Data/ProcessList.cs
+++ b/source/CapFrameX.Data/ProcessList.cs
@@ -165,14 +165,21 @@ namespace CapFrameX.Data
             {
                 try
                 {
-                    try
+                    if (File.Exists(fullpath))
                     {
                         processList.ReadFromFile();
                     }
-                    catch (Exception ex)
+                    else
                     {
-                        logger.LogError(ex, "Error while reading from file.");
+                        logger.LogDebug("Process list file not found at {Path}; starting from the bundled defaults.", fullpath);
                     }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Error while reading from file.");
+                }
+                try
+                {
 
                     var defaultProcesslistFileInfo = new FileInfo(Path.Combine("ProcessList", "Processes.json"));
                     if (!defaultProcesslistFileInfo.Exists)

--- a/source/CapFrameX.Sensor/SensorConfig.cs
+++ b/source/CapFrameX.Sensor/SensorConfig.cs
@@ -208,7 +208,15 @@ namespace CapFrameX.Sensor
 
         private async Task<Dictionary<string, bool>> GetInitializedSensorEntryDictionary()
         {
-            string json = await ReadAllTextAsync(Path.Combine(_sensorConfigFolder, CONFIG_FILENAME));
+            var path = Path.Combine(_sensorConfigFolder, CONFIG_FILENAME);
+
+            if (!File.Exists(path))
+            {
+                Log.Logger.Debug("Sensor config file not found at {Path}; using defaults.", path);
+                return null;
+            }
+
+            string json = await ReadAllTextAsync(path);
             return JsonConvert.DeserializeObject<Dictionary<string, bool>>(json);
         }
 


### PR DESCRIPTION
### Summary

On a clean portable install, `CapFrameX.log` shows `Error`-level entries for `SensorEntryConfiguration.json` and `Processes.json` on first launch:

Error while loading sensor config. Default config loading instead...
System.IO.FileNotFoundException: Could not find file '...\Config\SensorEntryConfiguration.json'.
...
Error while reading from file.
System.IO.FileNotFoundException: Could not find file '...\Config\Processes.json'.

Neither is an actual error, both are the expected "first run, config file doesn't exist yet" case, and both already fall back correctly (`SensorConfig` to its default dictionary, `ProcessList` to the bundled `ProcessList/Processes.json` template). The exception is just being used as control flow instead of being checked for up front.

Compare with the line right above them in the same log, for `AppSettings.json`, which already does this correctly:

File '...\Config\AppSettings.json' does not exist. Creating it...

### Changes

**`CapFrameX.Sensor/SensorConfig.cs`**
* `GetInitializedSensorEntryDictionary()` now checks `File.Exists()` before reading. If the file isn't there yet, logs at `Debug` and returns `null`, letting the existing fallback in `LoadOrSetDefault()` load defaults exactly as before. A file that exists but fails to read/parse (corrupt JSON, permissions) still throws and still logs as `Error`, unchanged.

**`CapFrameX.Data/ProcessList.cs`**
* `Create()` now checks `File.Exists()` before calling `ReadFromFile()`. If it's not there yet, logs at `Debug` and falls through to the existing bundled-defaults logic further down (unchanged). Genuine read failures still log as `Error`.

### Testing
Verified on a portable session on a fresh folder, both entries now log at `Debug` instead of `Error`, with identical fallback behavior (defaults load the same way, capture starts normally). Full log attached below for reference:

https://github.com/independent-arg/CapFrameX/actions/runs/33014546613

`{"@t":"2026-08-26T21:23:20.3794677Z","@mt":"Sensor config file not found at {Path}; using defaults.","@l":"Debug","Path":"C:\\Users\\test\\Downloads\\9aab0781b4d10103c7b74afa916b6336ace78911_portable\\Portable\\Config\\SensorEntryConfiguration.json"}`

`{"@t":"2026-08-26T21:23:20.3879732Z","@mt":"Process list file not found at {Path}; starting from the bundled defaults.","@l":"Debug","Path":"C:\\Users\\test\\Downloads\\9aab0781b4d10103c7b74afa916b6336ace78911_portable\\Portable\\Config\\Processes.json","SourceContext":"CapFrameX.Data.ProcessList"}`
