### PR TITLE
Upgrade NuGet package dependencies and clean up

### DIFF
--- a/source/CapFrameX.ApiInterface/CapFrameX.Remote.csproj
+++ b/source/CapFrameX.ApiInterface/CapFrameX.Remote.csproj
@@ -12,13 +12,13 @@
 
   <ItemGroup>
     <PackageReference Include="DryIoc.dll" Version="5.4.3" />
-    <PackageReference Include="EmbedIO" Version="3.4.3" />
+    <PackageReference Include="EmbedIO" Version="3.5.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
-    <PackageReference Include="Unosquare.Swan.Lite" Version="3.0.0" />
+    <PackageReference Include="Unosquare.Swan.Lite" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/CapFrameX.Extensions.NetStandard/CapFrameX.Extensions.NetStandard.csproj
+++ b/source/CapFrameX.Extensions.NetStandard/CapFrameX.Extensions.NetStandard.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="2.9.0" />

--- a/source/CapFrameX.Extensions/CapFrameX.Extensions.csproj
+++ b/source/CapFrameX.Extensions/CapFrameX.Extensions.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="DryIoc.dll" Version="5.4.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />

--- a/source/CapFrameX.Mcp/CapFrameX.Mcp.csproj
+++ b/source/CapFrameX.Mcp/CapFrameX.Mcp.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EmbedIO" Version="3.4.3" />
+    <PackageReference Include="EmbedIO" Version="3.5.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="DryIoc.dll" Version="5.4.3" />

--- a/source/CapFrameX.View/CapFrameX.View.csproj
+++ b/source/CapFrameX.View/CapFrameX.View.csproj
@@ -22,12 +22,12 @@
     <PackageReference Include="Extended.Wpf.Toolkit" Version="5.1.2" />
     <PackageReference Include="gong-wpf-dragdrop" Version="3.2.1" />
     <PackageReference Include="Jot" Version="2.1.17" />
-    <PackageReference Include="MahApps.Metro" Version="2.4.10" />
+    <PackageReference Include="MahApps.Metro" Version="2.4.11" />
     <PackageReference Include="MaterialDesignColors" Version="5.2.1" />
     <PackageReference Include="MaterialDesignThemes" Version="5.2.1" />
     <PackageReference Include="MaterialDesignThemes.MahApps" Version="5.2.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.1.0" />

--- a/source/CapFrameX.ViewModel/CapFrameX.ViewModel.csproj
+++ b/source/CapFrameX.ViewModel/CapFrameX.ViewModel.csproj
@@ -10,7 +10,7 @@
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <!-- MouseKeyHook/KeyMouseHook ship .NET Framework assets only; the IL is compatible with modern .NET. -->
+    <!-- MouseKeyHook ships .NET Framework assets only; the IL is compatible with modern .NET. -->
     <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>
 
@@ -20,10 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ParallelExtensionsExtras" Version="1.2.0" />
     <PackageReference Include="DynamicData" Version="6.14.8" />
     <PackageReference Include="gong-wpf-dragdrop" Version="3.2.1" />
-    <PackageReference Include="KeyMouseHook" Version="1.0.6" />
     <PackageReference Include="MaterialDesignColors" Version="5.2.1" />
     <PackageReference Include="MaterialDesignThemes" Version="5.2.1" />
     <PackageReference Include="MathNet.Filtering" Version="0.7.0" />
@@ -34,9 +32,9 @@
     <PackageReference Include="MouseKeyHook" Version="5.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Core" Version="2.1.0" />
+    <PackageReference Include="ParallelExtensionsExtras" Version="1.2.0" />
     <PackageReference Include="Prism.Core" Version="9.0.537" />
     <PackageReference Include="Prism.Wpf" Version="9.0.537" />
-    <PackageReference Include="Splat" Version="9.3.11" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
     <PackageReference Include="TaskScheduler" Version="2.9.1" />
   </ItemGroup>

--- a/source/CapFrameX.Webservice.Data/CapFrameX.Webservice.Data.csproj
+++ b/source/CapFrameX.Webservice.Data/CapFrameX.Webservice.Data.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <PackageReference Include="AutoMapper" Version="16.2.0" />
     <PackageReference Include="FluentValidation" Version="8.6.2" />
     <PackageReference Include="MediatR" Version="8.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.12" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Squidex.ClientLibrary" Version="4.2.0" />

--- a/source/CapFrameX.Webservice.Host/CapFrameX.Webservice.Host.csproj
+++ b/source/CapFrameX.Webservice.Host/CapFrameX.Webservice.Host.csproj
@@ -14,24 +14,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <PackageReference Include="AutoMapper" Version="16.2.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="FluentValidation" Version="8.6.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
     <PackageReference Include="MediatR" Version="8.0.1" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.12" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />

--- a/source/CapFrameX.Webservice.Implementation/CapFrameX.Webservice.Implementation.csproj
+++ b/source/CapFrameX.Webservice.Implementation/CapFrameX.Webservice.Implementation.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="16.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
+    <PackageReference Include="AutoMapper" Version="16.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.12" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Squidex.ClientLibrary" Version="4.2.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />

--- a/source/CapFrameX/CapFrameX.csproj
+++ b/source/CapFrameX/CapFrameX.csproj
@@ -74,13 +74,13 @@
 
   <ItemGroup>
     <PackageReference Include="DryIoc.dll" Version="5.4.3" />
-    <PackageReference Include="EmbedIO" Version="3.4.3" />
+    <PackageReference Include="EmbedIO" Version="3.5.2" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
     <PackageReference Include="Jot" Version="2.1.17" />
     <PackageReference Include="MaterialDesignColors" Version="5.2.1" />
     <PackageReference Include="MaterialDesignThemes" Version="5.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.12" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Prism.Core" Version="9.0.537" />
     <PackageReference Include="Prism.DryIoc" Version="9.0.537" />


### PR DESCRIPTION
Bump a few low-risk packages, drop dead dependencies

**Version bumps (all patch/minor, no breaking API changes):**
- MahApps.Metro 2.4.10 → 2.4.11
- EmbedIO 3.4.3 → 3.5.2 (CapFrameX.Remote, CapFrameX.Mcp, CapFrameX)
- AutoMapper 16.1.1 → 16.2.0 (Webservice.Data/Host/Implementation)
- Microsoft.AspNetCore.Http / .Http.Abstractions 2.3.9 → 2.3.12
- Microsoft.Extensions.Logging 6.0.0 → 10.0.5, to match `.Abstractions` which
  was already on 10.0.5 everywhere else (CapFrameX.Extensions,
  CapFrameX.Extensions.NetStandard, CapFrameX.View)

Bumping EmbedIO raised its floor on Unosquare.Swan.Lite to >=3.1.0, which
conflicted with the 3.0.0 pin in CapFrameX.Remote (NU1605 treated as an
error). Bumped that pin to 3.1.0 to match.

Same thing happened bumping Microsoft.Extensions.Logging: it raised the floor
on Microsoft.Extensions.DependencyInjection to >=10.0.5, conflicting with the
6.0.0 pin in CapFrameX.View. Bumped that one too.

**Removed (unused):**
- `Microsoft.EntityFrameworkCore.Design` (Webservice.Host), no DbContext anywhere in the repo, leftover from before the EF persistence layer was dropped
- `Microsoft.VisualStudio.Web.CodeGeneration.Design` (Webservice.Host), scaffolding tool, not referenced anywhere
- `KeyMouseHook` (CapFrameX.ViewModel), dead duplicate of the actually-used `MouseKeyHook` package, only ever ended up in the installer output with no code referencing it
- `Splat` (CapFrameX.ViewModel), no usage anywhere in the codebase

Verified: https://github.com/independent-arg/CapFrameX/actions/runs/33232780271